### PR TITLE
Add support for `detekt_input` argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,13 @@ To enable declare `detekt_all_rules: true`
 
 [Read more](https://detekt.github.io/detekt/cli.html)
 
+### `detekt_input`
+
+Optional. Specify explicit inputs to detect-cli.
+Inputs provided as a comma-separated string.
+
+[Read more](https://detekt.github.io/detekt/cli.html)
+
 ## Usage
 
 Following example runs detekt with

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ jobs:
           ref: ${{ github.head_ref }}
 
       - name: detekt
-        uses: alaegin/Detekt-Action@v1.23.1
+        uses: alaegin/Detekt-Action@v1.23.1.1
         with:
           github_token: ${{ secrets.github_token }}
           detekt_config: detekt-config.yml # Change config path

--- a/action.yml
+++ b/action.yml
@@ -54,6 +54,11 @@ inputs:
   detekt_all_rules:
     description: 'Activates all available (even unstable) rules.'
     required: false
+  detekt_input:
+    description: |
+      'Specific inputs for detekt (the --input argument for detekt-cli)'
+      Example: 'path/to/dir1,path/to/dir2'
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -70,6 +75,7 @@ runs:
     - ${{ inputs.detekt_parallel }}
     - ${{ inputs.detekt_build_upon_default_config }}
     - ${{ inputs.detekt_all_rules }}
+    - ${{ inputs.detekt_input }}
 branding:
   icon: 'check-square'
   color: 'orange'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -40,6 +40,10 @@ if [ -n "$DETEKT_ALL_RULES" ]; then
   detekt_command+="--all-rules "
 fi
 
+if [ -n "$DETEKT_INPUT" ]; then
+    detekt_command+="--input ${DETEKT_INPUT} "
+fi
+
 echo "$detekt_command"
 eval "$detekt_command"
 


### PR DESCRIPTION
On a large repository, I have detekt hanging unless I explicity provide the input paths.

This adds support for `detekt_input` as an argument, which in turn transforms into a `--input ...` argument in the detekt-cli execution.