### PR TITLE
Bump detekt to 1.23.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.13.1
 
 # https://github.com/detekt/detekt/releases
-ARG DETEKT_VERSION="1.23.0"
+ARG DETEKT_VERSION="1.23.1"
 # https://github.com/reviewdog/reviewdog/releases
 ARG REVIEWDOG_VERSION="0.14.1"
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ jobs:
           ref: ${{ github.head_ref }}
 
       - name: detekt
-        uses: alaegin/Detekt-Action@v1.23.0
+        uses: alaegin/Detekt-Action@v1.23.1
         with:
           github_token: ${{ secrets.github_token }}
           detekt_config: detekt-config.yml # Change config path


### PR DESCRIPTION
Bump detekt version to 1.23.1 for release https://github.com/detekt/detekt/releases/tag/v1.23.1